### PR TITLE
chore: add actions to automatically create a new tag and release after every commit to master

### DIFF
--- a/.github/workflows/auto-release-notes.yml
+++ b/.github/workflows/auto-release-notes.yml
@@ -1,0 +1,23 @@
+
+name: "auto-release-notes"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tagged-release:
+    name: "auto-release-notes"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      # ...
+      - name: "Build & test"
+        run: |
+          echo "done!"
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.ACCESS_TOKEN }}"
+          prerelease: false

--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,16 @@
+
+name: bump-tag
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Github Tag Bump
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        DEFAULT_BUMP: none

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ And fully containerized development
 ## Information About the Common Utility Functions
 Each library has it's own `README.md` on it's folder under `/src/lib`. e.g for `input-validation`, the README is in `/src/lib/input-validation/README.md`
 
+## Merge to master Branch Quick Start
+Currently we have two GitHub actions that will automatically create a new tag and a new release everytime a commit is merged to master branch. 
+Things you should pay attention to before merging your work to master branch :
+- Make sure to update `CHANGELOG.md` to keep track on what's updated in the repo
+- If you want to update the minor version, add `#minor` at the end of your commit message (ex: `fix(some_validation): some message #minor`)
+- The same goes if you want to update the major or patch version, add `#major` or `#patch` at the end of your commit message
+- If you don't add one of those three to your commit message, the Github actions will not automatically create a new tag and release notes
+
 ## Development Quick Start
 
 run `make build`, to build the project


### PR DESCRIPTION
this may save repo maintainers' time from manually add a new tag and release. [justice-ui-library](https://github.com/AccelByte/justice-ui-library/pull/8) already implemented this